### PR TITLE
Improve translation model handling

### DIFF
--- a/SpeakingAR/ContentView.swift
+++ b/SpeakingAR/ContentView.swift
@@ -32,7 +32,7 @@ struct ContentView: View {
 
                 RecordButton(isRecording: transcriber.isRecording) {
                     if transcriber.isRecording {
-                        transcriber.stopTranscribing()
+                        transcriber.stopTranscribing(userInitiated: true)
                     } else {
                         transcriber.startTranscribing()
                     }


### PR DESCRIPTION
## Summary
- ensure translation models are downloaded before starting a session and reuse prepared translation sessions safely
- preload English↔Japanese language pairs and retry translations after transient outages instead of disabling translation permanently
- surface clearer translation status messaging while resources are prepared and automatically recover from failures

## Testing
- not run (not available)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691088ce5fc08327bb66de0a7a3345f4)